### PR TITLE
Add logout request to AJAX call in panel.php

### DIFF
--- a/src/panel.php
+++ b/src/panel.php
@@ -435,6 +435,14 @@
             }).then((result) => {
                 if (result.isConfirmed) {
                     sessionStorage.removeItem('credentials');
+                    $.ajax({
+                        url: 'login',
+                        type: 'DELETE',
+                        success: function(result) {
+                            // Handle success response here
+                            console.log('Deleted successfully');
+                        }
+                    });
                     Swal.fire({
                         title: 'Logged out successfully!',
                         text: "You have been logged out of your account.",
@@ -458,6 +466,14 @@
             }).then((result) => {
                 if (result.isConfirmed) {
                     sessionStorage.removeItem('credentials');
+                    $.ajax({
+                        url: 'login',
+                        type: 'DELETE',
+                        success: function(result) {
+                            // Handle success response here
+                            console.log('Deleted successfully');
+                        }
+                    });
                     Swal.fire({
                         title: 'Úspešné odhlásenie!',
                         text: "Boli ste úspešne odhlásení zo svojho účtu.",


### PR DESCRIPTION
The changes in this commit add an AJAX call that explicitly requests a logout from the server when the user chooses to log out. This ensures that sessions are properly closed on the server-side as well, adding an extra layer of security and performance optimization.